### PR TITLE
Increase timeout to 4 seconds.

### DIFF
--- a/rml-decisiontrees/main.rkt
+++ b/rml-decisiontrees/main.rkt
@@ -67,7 +67,7 @@
 
 (define evaluator-memory-limit 16) ;; Mb
 
-(define evaluator-time-limit 2.0) ;; seconds
+(define evaluator-time-limit 4.0) ;; seconds
 
 (define (tree-classify tree individual)
   (evaluate-tree tree individual))


### PR DESCRIPTION
Currently this test fails on many machines, including
https://plt.eecs.northwestern.edu/pkg-build/server/built/test-fail/rml-decisiontrees.txt